### PR TITLE
update setup.sh to use codespace secrets for certs

### DIFF
--- a/airs-setup.sh
+++ b/airs-setup.sh
@@ -36,6 +36,12 @@ then
   exit 1
 fi
 
+if [ -z "$INGRESS_KEY" ]
+then
+  echo Ingress SSL private key is missing
+  exit 1
+fi
+
 # change to this directory
 cd $(dirname $0)
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -39,7 +39,6 @@ export ASB_CLUSTER_ADMIN_GROUP=cluster-admins-$ASB_TEAM_NAME
 export ASB_AKS_NAME=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.aksClusterName.value -o tsv)
 export ASB_KEYVAULT_NAME=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.keyVaultName.value -o tsv)
 export ASB_LA_HUB=$(az monitor log-analytics workspace list -g $ASB_RG_HUB --query [0].name -o tsv)
-export ASB_POD_MI_ID=$(az identity show -n podmi-ingress-controller -g $ASB_RG_CORE --query principalId -o tsv)
 
 if [ -v "$ASB_KEYVAULT_NAME" ]
 then
@@ -57,9 +56,6 @@ az ad group delete -g $ASB_CLUSTER_ADMIN_GROUP
 
 # delete DNS record
 az network dns record-set a delete -g tld -z aks-sb.com -y -n $ASB_TEAM_NAME
-
-# delete access policy to shared key vault
-az keyvault delete-policy --object-id $ASB_POD_MI_ID -n $ASB_SHARED_KV_NAME
 
 # delete the resource groups
 az group delete -y --no-wait -g $ASB_RG_CORE

--- a/setup.sh
+++ b/setup.sh
@@ -161,6 +161,9 @@ az deployment group create -g $ASB_RG_CORE \
       aksIngressControllerCertificate="$(echo $INGRESS_CERT | base64 -d)" \
       aksIngressControllerKey="$(echo $INGRESS_KEY | base64 -d)"
 
+# get the name of the deployment key vault
+export ASB_KV_NAME=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.keyVaultName.value -o tsv)
+
 # get cluster name
 export ASB_AKS_NAME=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.aksClusterName.value -o tsv)
 

--- a/setup.sh
+++ b/setup.sh
@@ -36,17 +36,6 @@ then
 fi
 export ASB_DOMAIN=${ASB_TEAM_NAME}.${ASB_DNS_ZONE}
 
-# set default shared cert values
-if [ -z "$ASB_KV_NAME" ]
-then
-  export ASB_KV_NAME=kv-tld
-fi
-
-if [ -z "$ASB_CERT_NAME" ]
-then
-  export ASB_CERT_NAME=aks-sb
-fi
-
 # set default location
 if [ -z "$ASB_LOCATION" ]
 then
@@ -156,10 +145,6 @@ export ASB_NODEPOOLS_SUBNET_ID=$(az deployment group show -g $ASB_RG_SPOKE -n sp
 az deployment group create -g $ASB_RG_HUB -f networking/hub-regionA.json -p location=${ASB_LOCATION} nodepoolSubnetResourceIds="['${ASB_NODEPOOLS_SUBNET_ID}']"
 export ASB_SPOKE_VNET_ID=$(az deployment group show -g $ASB_RG_SPOKE -n spoke-BU0001A0008 --query properties.outputs.clusterVnetResourceId.value -o tsv)
 
-# grant executer permission to the key vault
-az keyvault set-policy --certificate-permissions list get --object-id $(az ad signed-in-user show --query objectId -o tsv) -n $ASB_KV_NAME -g TLD
-az keyvault set-policy --secret-permissions list get --object-id $(az ad signed-in-user show --query objectId -o tsv) -n $ASB_KV_NAME -g TLD
-
 # create AKS
 az deployment group create -g $ASB_RG_CORE \
   -f cluster-stamp.json \
@@ -172,12 +157,9 @@ az deployment group create -g $ASB_RG_CORE \
       targetVnetResourceId=${ASB_SPOKE_VNET_ID} \
       clusterAdminAadGroupObjectId=${ASB_CLUSTER_ADMIN_ID} \
       k8sControlPlaneAuthorizationTenantId=${ASB_TENANT_ID} \
-      appGatewayListenerCertificate=$(az keyvault secret show --vault-name $ASB_KV_NAME -n $ASB_CERT_NAME --query "value" -o tsv | tr -d '\n') \
-      aksIngressControllerCertificate="not used" \
-      aksIngressControllerKey="not used"
-
-# Remove user's permissions from shared keyvault. It is no longer needed after this step.
-az keyvault delete-policy --object-id $(az ad signed-in-user show --query objectId -o tsv) -n $ASB_KV_NAME
+      appGatewayListenerCertificate=${APP_GW_CERT} \
+      aksIngressControllerCertificate="$(echo $INGRESS_CERT | base64 -d)" \
+      aksIngressControllerKey="$(echo $INGRESS_KEY | base64 -d)"
 
 # get cluster name
 export ASB_AKS_NAME=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.aksClusterName.value -o tsv)
@@ -191,17 +173,13 @@ az network dns record-set a add-record -a $ASB_AKS_PIP -n $ASB_TEAM_NAME -g TLD 
 # Get the AKS Ingress Controller Managed Identity details.
 export ASB_TRAEFIK_RESOURCE_ID=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.aksIngressControllerPodManagedIdentityResourceId.value -o tsv)
 export ASB_TRAEFIK_CLIENT_ID=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.aksIngressControllerPodManagedIdentityClientId.value -o tsv)
-export ASB_POD_MI_ID=$(az identity show -n podmi-ingress-controller -g $ASB_RG_CORE --query principalId -o tsv)
 
 # save env vars
 ./saveenv.sh -y
 
-az keyvault set-policy --certificate-permissions get --object-id $ASB_POD_MI_ID -n $ASB_KV_NAME
-az keyvault set-policy --secret-permissions get --object-id $ASB_POD_MI_ID -n $ASB_KV_NAME
-
 # config traefik
-export ASB_INGRESS_CERT_NAME=aks-sb-crt
-export ASB_INGRESS_KEY_NAME=$ASB_CERT_NAME
+export ASB_INGRESS_CERT_NAME=appgw-ingress-internal-aks-ingress-tls
+export ASB_INGRESS_KEY_NAME=appgw-ingress-internal-aks-ingress-key
 
 rm -f gitops/ingress/02-traefik-config.yaml
 cat templates/traefik-config.yaml | envsubst  > gitops/ingress/02-traefik-config.yaml

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,25 @@ then
   exit 1
 fi
 
+# check certs
+if [ -z "$APP_GW_CERT" ]
+then
+  echo App Gateway SSL certificate is missing
+  exit 1
+fi
+
+if [ -z "$INGRESS_CERT" ]
+then
+  echo Ingress SSL certificate is missing
+  exit 1
+fi
+
+if [ -z "$INGRESS_KEY" ]
+then
+  echo Ingress SSL private key is missing
+  exit 1
+fi
+
 # change to this directory
 cd $(dirname $0)
 


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Update setup.sh script to use codespace secrets for certs. This allows the deployment to use the instance keyvault for certificates instead of relying on access to a shared pre existing key vault.

Link for test deployment using updated script. https://ak02.aks-sb.com/memory/index.html

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/asb-hack/issues/260
