### PR TITLE
Documentation for setting up ngsa-cosmos in ASB

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -1212,7 +1212,7 @@
                     "authorizedIPRanges": "[parameters('clusterAuthorizedIPRanges')]",
                     "enablePrivateCluster": false
                 },
-                "podIdentityProfile": { 
+                "podIdentityProfile": {
                     "enabled": false, /* This feature is currently in preview and will eventually replace the aad-pod-identity configuration set up by hand in this reference implementation */
                     "userAssignedIdentities": [],
                     "userAssignedIdentityExceptions": []
@@ -2069,6 +2069,10 @@
         "containerRegistryName": {
             "type": "string",
             "value": "[variables('defaultAcrName')]"
+        },
+        "vnetNodePoolSubnetResourceId": {
+            "type": "string",
+            "value": "[variables('vnetNodePoolSubnetResourceId')]"
         }
     }
 }

--- a/docs/cosmos.md
+++ b/docs/cosmos.md
@@ -88,6 +88,9 @@ az keyvault secret set -o table --vault-name $ASB_KV_NAME --name "CosmosKey" \
   --value $(az cosmosdb keys list -n $ASB_IMDB_NAME -g $ASB_RG_CORE --query primaryMasterKey -o tsv)
 az keyvault secret set -o table --vault-name $ASB_KV_NAME --name "CosmosUrl" --value "https://${ASB_IMDB_NAME}.documents.azure.com:443/"
 
+# remove logged in user's access to key vault
+az keyvault delete-policy --object-id $(az ad signed-in-user show --query objectId -o tsv) -n $ASB_KV_NAME -g $ASB_RG_CORE
+
 ```
 
 ## Create managed identity for app
@@ -149,13 +152,22 @@ git push
 
 ```
 
+Flux will pick up the latest changes. Use the command below to force flux to sync.
+
+```bash
+
+# force flux to sync changes
+fluxctl sync
+
+```
+
 ## Validate
 
 ```bash
 
 # wait for ngsa-cosmos pods to start
 ### this can take 8-10 minutes as the cluster sets up pod identity, and secrets via the csi driver
-kubectl get pods -n ingress
+kubectl get pods -n ngsa
 
 curl https://${ASB_DOMAIN}/cosmos/version
 

--- a/docs/cosmos.md
+++ b/docs/cosmos.md
@@ -128,6 +128,7 @@ az keyvault set-policy -n $ASB_KV_NAME --object-id $ASB_NGSA_MI_PRINCIPAL_ID --s
 export ASB_NGSA_MI_CLIENT_ID=$(az identity show -n $ASB_NGSA_MI_NAME -g $ASB_RG_CORE --query "clientId" -o tsv)
 
 cat templates/ngsa-cosmos.yaml | envsubst > gitops/ngsa/ngsa-cosmos.yaml
+cat templates/ngsa-pod-identity.yaml | envsubst > gitops/ngsa/ngsa-pod-identity.yaml
 
 # save env vars
 ./saveenv.sh -y
@@ -152,8 +153,10 @@ git push
 
 ```bash
 
-# TODO:
-# - add comment on timing of how long pods take to go to running state if it is more than 1 minute
-# - add commands to check pods and logs
+# wait for ngsa-cosmos pods to start
+### this can take 8-10 minutes as the cluster sets up pod identity, and secrets via the csi driver
+kubectl get pods -n ingress
+
+curl https://${ASB_DOMAIN}/cosmos/version
 
 ```

--- a/docs/cosmos.md
+++ b/docs/cosmos.md
@@ -1,0 +1,159 @@
+# Cosmos DB in AKS secure baseline
+
+Prerequisites:
+
+- Follow setup instructions in [README.md](../README.md) to create an environment
+
+## Create cosmos
+
+```bash
+
+export ASB_IMDB_NAME="${ASB_TEAM_NAME}-cosmos"
+export ASB_IMDB_DB="imdb"
+export ASB_IMDB_COL="movies"
+export ASB_IMDB_RW_KEY="az cosmosdb keys list -n $ASB_IMDB_NAME -g $ASB_RG_CORE --query primaryMasterKey -o tsv"
+
+# create cosmos
+export ASB_COSMOS_ID=$(az cosmosdb create -g $ASB_RG_CORE -n $ASB_IMDB_NAME --query id -o tsv)
+az cosmosdb sql database create -a $ASB_IMDB_NAME -n $ASB_IMDB_DB -g $ASB_RG_CORE --throughput 1000
+az cosmosdb sql container create -p /partitionKey -g $ASB_RG_CORE -a $ASB_IMDB_NAME -d $ASB_IMDB_DB -n $ASB_IMDB_COL
+
+# save env vars
+./saveenv.sh -y
+
+```
+
+## Load data into cosmos
+
+```bash
+
+# load data into cosmos
+docker run -it --rm retaildevcrew/imdb-import $ASB_IMDB_NAME $(eval $ASB_IMDB_RW_KEY) $ASB_IMDB_DB $ASB_IMDB_COL
+
+```
+
+## Setup private connection
+
+```bash
+
+# subnet for AKS cluster nodes
+export ASB_NODES_SUBNET_ID=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_TEAM_NAME} --query properties.outputs.vnetNodePoolSubnetResourceId.value -o tsv)
+
+# create private endpoint
+az network private-endpoint create \
+  --name "nodepools-to-cosmos-endpoint" \
+  --connection-name "nodepools-to-cosmos-connection" \
+  --resource-group $ASB_RG_CORE \
+  --subnet $ASB_NODES_SUBNET_ID \
+  --private-connection-resource-id $ASB_COSMOS_ID \
+  --group-id "Sql"
+
+# create private dns zone
+# recommended zone names: https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration
+export ASB_COSMOS_ZONE="privatelink.documents.azure.com"
+az network private-dns zone create --resource-group $ASB_RG_CORE --name $ASB_COSMOS_ZONE
+
+# create vnet link between private zone and spoke vnet
+az network private-dns link vnet create \
+  --resource-group $ASB_RG_CORE \
+  --zone-name  $ASB_COSMOS_ZONE \
+  --name "nodepools-to-cosmos-link" \
+  --virtual-network $ASB_SPOKE_VNET_ID \
+  --registration-enabled false
+
+# create a DNS zone group to add cosmos dns records to private dns zone
+az network private-endpoint dns-zone-group create \
+  --resource-group $ASB_RG_CORE \
+  --endpoint-name "nodepools-to-cosmos-endpoint" \
+  --name "nodepools-to-cosmos-zone-group" \
+  --private-dns-zone $ASB_COSMOS_ZONE \
+  --zone-name $ASB_TEAM_NAME
+
+# save env vars
+./saveenv.sh -y
+
+```
+
+## Add app secrets to key vault
+
+```bash
+
+# give logged in user access to key vault
+az keyvault set-policy --secret-permissions set --object-id $(az ad signed-in-user show --query objectId -o tsv) -n $ASB_KV_NAME -g $ASB_RG_CORE
+
+# set app secrets
+az keyvault secret set -o table --vault-name $ASB_KV_NAME --name "CosmosDatabase" --value $ASB_IMDB_DB
+az keyvault secret set -o table --vault-name $ASB_KV_NAME --name "CosmosCollection" --value $ASB_IMDB_COL
+az keyvault secret set -o table --vault-name $ASB_KV_NAME --name "CosmosKey" \
+  --value $(az cosmosdb keys list -n $ASB_IMDB_NAME -g $ASB_RG_CORE --query primaryMasterKey -o tsv)
+az keyvault secret set -o table --vault-name $ASB_KV_NAME --name "CosmosUrl" --value "https://${ASB_IMDB_NAME}.documents.azure.com:443/"
+
+```
+
+## Create managed identity for app
+
+```bash
+
+# create managed identity for ngsa-app
+export ASB_NGSA_MI_NAME="${ASB_TEAM_NAME}-ngsa-id"
+
+export ASB_NGSA_MI_RESOURCE_ID=$(az identity create -g $ASB_RG_CORE -n $ASB_NGSA_MI_NAME --query "id" -o tsv)
+
+# save env vars
+./saveenv.sh -y
+
+```
+
+## AAD pod identity setup for app
+
+```bash
+
+# allow cluster to manage app identity for aad pod identity
+export ASB_AKS_IDENTITY_ID=$(az aks show -g $ASB_RG_CORE -n $ASB_AKS_NAME --query "identityProfile.kubeletidentity.objectId" -o tsv)
+az role assignment create --role "Managed Identity Operator" --assignee $ASB_AKS_IDENTITY_ID --scope $ASB_NGSA_MI_RESOURCE_ID
+
+# give app identity read access to secrets in keyvault
+export ASB_NGSA_MI_PRINCIPAL_ID=$(az identity show -n $ASB_NGSA_MI_NAME -g $ASB_RG_CORE --query "principalId" -o tsv)
+az keyvault set-policy -n $ASB_KV_NAME --object-id $ASB_NGSA_MI_PRINCIPAL_ID --secret-permissions get
+
+# save env vars
+./saveenv.sh -y
+
+```
+
+## Create ngsa-cosmos deployment file
+
+```bash
+
+export ASB_NGSA_MI_CLIENT_ID=$(az identity show -n $ASB_NGSA_MI_NAME -g $ASB_RG_CORE --query "clientId" -o tsv)
+
+cat templates/ngsa-cosmos.yaml | envsubst > gitops/ngsa/ngsa-cosmos.yaml
+
+# save env vars
+./saveenv.sh -y
+
+```
+
+## Push to GitHub
+
+```bash
+
+# check deltas - there should be 1 new file
+git status
+
+# push to your branch
+git add .
+git commit -m "added ngsa-cosmos config"
+git push
+
+```
+
+## Validate
+
+```bash
+
+# TODO:
+# - add comment on timing of how long pods take to go to running state if it is more than 1 minute
+# - add commands to check pods and logs
+
+```

--- a/templates/ngsa-cosmos.yaml
+++ b/templates/ngsa-cosmos.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ngsa-cosmos
+  namespace: ngsa
+  labels:
+    app.kubernetes.io/name: ngsa-cosmos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ngsa-cosmos
+  template:
+    metadata:
+      labels:
+        app: ngsa-cosmos
+        aadpodidbinding: $ASB_NGSA_MI_NAME
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8080'
+    spec:
+      containers:
+        - name: app
+          image: retaildevcrew/ngsa-app:beta
+          imagePullPolicy: Always
+
+          args:
+          - --prometheus
+          - --url-prefix
+          - /cosmos
+          - --zone
+          - az-eastus2
+          - --region
+          - East
+
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+
+          volumeMounts:
+            - name: secrets
+              mountPath: "/app/secrets"
+      volumes:
+        - name: secrets
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: ngsa-secrets
+
+      nodeSelector:
+        agentpool: npuser01
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ngsa-cosmos
+  namespace: ngsa
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: ngsa-cosmos
+
+---
+
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: $ASB_NGSA_MI_NAME
+  namespace: ngsa
+spec:
+  type: 0
+  resourceID: $ASB_NGSA_MI_RESOURCE_ID
+  clientID: $ASB_NGSA_MI_CLIENT_ID
+
+---
+
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentityBinding
+metadata:
+  name: ${ASB_NGSA_MI_NAME}-binding
+  namespace: ngsa
+spec:
+  azureIdentity: $ASB_NGSA_MI_NAME
+  selector: $ASB_NGSA_MI_NAME
+
+---
+
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: ngsa-secrets
+  namespace: ngsa
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "true"
+    keyvaultName: "$ASB_KV_NAME"
+    objects: |
+      array:
+        - |
+          objectName: CosmosDatabase
+          objectType: secret
+        - |
+          objectName: CosmosCollection
+          objectType: secret
+        - |
+          objectName: CosmosKey
+          objectType: secret
+        - |
+          objectName: CosmosUrl
+          objectType: secret
+    tenantId: "$ASB_TENANT_ID"

--- a/templates/ngsa-cosmos.yaml
+++ b/templates/ngsa-cosmos.yaml
@@ -79,51 +79,30 @@ spec:
 
 ---
 
-apiVersion: aadpodidentity.k8s.io/v1
-kind: AzureIdentity
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: $ASB_NGSA_MI_NAME
+  name: ngsa-cosmos-ingress
   namespace: ngsa
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.class: traefik-internal
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.options: default
+    traefik.ingress.kubernetes.io/router.middlewares: ngsa-stripprefix@file
 spec:
-  type: 0
-  resourceID: $ASB_NGSA_MI_RESOURCE_ID
-  clientID: $ASB_NGSA_MI_CLIENT_ID
-
----
-
-apiVersion: aadpodidentity.k8s.io/v1
-kind: AzureIdentityBinding
-metadata:
-  name: ${ASB_NGSA_MI_NAME}-binding
-  namespace: ngsa
-spec:
-  azureIdentity: $ASB_NGSA_MI_NAME
-  selector: $ASB_NGSA_MI_NAME
-
----
-
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
-kind: SecretProviderClass
-metadata:
-  name: ngsa-secrets
-  namespace: ngsa
-spec:
-  provider: azure
-  parameters:
-    usePodIdentity: "true"
-    keyvaultName: "$ASB_KV_NAME"
-    objects: |
-      array:
-        - |
-          objectName: CosmosDatabase
-          objectType: secret
-        - |
-          objectName: CosmosCollection
-          objectType: secret
-        - |
-          objectName: CosmosKey
-          objectType: secret
-        - |
-          objectName: CosmosUrl
-          objectType: secret
-    tenantId: "$ASB_TENANT_ID"
+  tls:
+  - hosts:
+      - ${ASB_DOMAIN}
+  rules:
+  - host: ${ASB_DOMAIN}
+    http:
+      paths:
+      - path: /cosmos
+        pathType: Prefix
+        backend:
+          service:
+            name: ngsa-cosmos
+            port:
+              number: 8080

--- a/templates/ngsa-ingress.yaml
+++ b/templates/ngsa-ingress.yaml
@@ -35,10 +35,3 @@ spec:
             name: ngsa-memory
             port:
               number: 8080
-      - path: /cosmos
-        pathType: Prefix
-        backend:
-          service:
-            name: ngsa-cosmos
-            port:
-              number: 8080

--- a/templates/ngsa-ingress.yaml
+++ b/templates/ngsa-ingress.yaml
@@ -35,3 +35,10 @@ spec:
             name: ngsa-memory
             port:
               number: 8080
+      - path: /cosmos
+        pathType: Prefix
+        backend:
+          service:
+            name: ngsa-cosmos
+            port:
+              number: 8080

--- a/templates/ngsa-pod-identity.yaml
+++ b/templates/ngsa-pod-identity.yaml
@@ -1,0 +1,48 @@
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: $ASB_NGSA_MI_NAME
+  namespace: ngsa
+spec:
+  type: 0
+  resourceID: $ASB_NGSA_MI_RESOURCE_ID
+  clientID: $ASB_NGSA_MI_CLIENT_ID
+
+---
+
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentityBinding
+metadata:
+  name: ${ASB_NGSA_MI_NAME}-binding
+  namespace: ngsa
+spec:
+  azureIdentity: $ASB_NGSA_MI_NAME
+  selector: $ASB_NGSA_MI_NAME
+
+---
+
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: ngsa-secrets
+  namespace: ngsa
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "true"
+    keyvaultName: "$ASB_KV_NAME"
+    objects: |
+      array:
+        - |
+          objectName: CosmosDatabase
+          objectType: secret
+        - |
+          objectName: CosmosCollection
+          objectType: secret
+        - |
+          objectName: CosmosKey
+          objectType: secret
+        - |
+          objectName: CosmosUrl
+          objectType: secret
+    tenantId: "$ASB_TENANT_ID"


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Add documentation and templates for setting up cosmos and ngsa-cosmos in the AKS Baseline.

- Disable public access to cosmos
- Setup private link between cosmos and aks
- use pod identity and azure csi provider to mount cosmos secrets from key vault

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/asb-hack/issues/358
- References https://github.com/retaildevcrews/asb-hack/issues/231
